### PR TITLE
Make desk base height a config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,11 @@ Configuration can be provided with a file, or via command line arguments. Use `-
 Config options:
 
 - `mac_address` - The MAC address of the desk. This is required.
+- `base_height` - The lowest possible height (mm) of the desk top from the floor. Default `620`.
 - `stand_height` - The standing height (mm) from the floor of the desk Default `1040`.
-- `sit_height` - The standing height (mm) from the floor of the desk. Default `683`.
+- `sit_height` - The sitting height (mm) from the floor of the desk. Default `683`.
+- `stand_height_offset` - The standing height (mm) as an offset from base_height. Overrides `stand_height` if specified.
+- `sit_height_offset` - The sitting height (mm) as an offset from base_height. Overrides `sit_height` if specified.
 - `adapter_name` - The adapter name for the bluetooth adapter to use for the connection (Linux only). Default `hci0`
 - `height_tolerance` - Distance (mm) between reported height and target height before ceasing move commands. Default `2.0`
 - `scan_timeout` - Timeout to scan for the device (seconds). Default `5`


### PR DESCRIPTION
The tabletops of my Idasens measure 61 cm @ lowest setting to 126 cm @ highest setting, which is 1cm lower than the nonconfigurable default base height used here (details on that below).

tldr:
- This repository uses as default: 62, 127 (+65cm range of motion)
- I measured: 61, 126 (+65cm range of motion)
- [Ikea specifies](https://www.ikea.com/us/en/images/products/idasen-desk-sit-stand-brown-dark-gray__0685806_pe721491_s5.jpg): 63, 127 cm (+64cm range of motion)

This commit adds a `base_height` config option / `base-height` argument. It also adds two more options/arguments, `sit_height_offset` and `stand_height_offset`. Those allow specifying an amount of mm above the base height, and then the absolute height to use is calculated at runtime. To maintain backwards compatibility, the sit/stand_height options are unchanged. The new `*_height_offset` options are not required, but if specified they will override the existing `*_height` options.

---

Measurement data:

One Idasen was purchased two years ago and used on a wooden floor; I measured it at that time and noted down the values since I myself was reverse engineering the bluetooth protocol.

The current one was purchased a few months ago at a different location and measured with a different measuring tape, on carpet.

My measuring tapes only had/have inches. The actual measurements on my current desk were just a bit (less than 1/4") under 24" (60.96 cm) at the lowest setting, and almost exactly 49.5" (125.73 cm) at the top. For my old desk, I had 24" and 49.75" saved in my notepad. When measuring, I did make sure to keep the tape perpendicular to the ground and desk, so I have no reason to believe that these values are inaccurate for my desks.