### PR TITLE
Add movement range config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Config options:
 
 - `mac_address` - The MAC address of the desk. This is required.
 - `base_height` - The lowest possible height (mm) of the desk top from the floor. Default `620`.
+- `movement_range` - How far above base-height the desk can extend (mm). Default `650`.
 - `stand_height` - The standing height (mm) from the floor of the desk Default `1040`.
 - `sit_height` - The sitting height (mm) from the floor of the desk. Default `683`.
 - `stand_height_offset` - The standing height (mm) as an offset from base_height. Overrides `stand_height` if specified.

--- a/idasen_controller/main.py
+++ b/idasen_controller/main.py
@@ -56,11 +56,12 @@ if not os.path.isfile(DEFAULT_CONFIG_PATH):
 # Height of the desk at it's lowest (in mm)
 DEFAULT_BASE_HEIGHT = 620
 # And how high it can rise above that (same for all desks)
-MOVEMENT_RANGE = 650
+DEFAULT_MOVEMENT_RANGE = 650
 
 config = {
     "mac_address": None,
     "base_height": DEFAULT_BASE_HEIGHT,
+    "movement_range": DEFAULT_MOVEMENT_RANGE,
     "stand_height": DEFAULT_BASE_HEIGHT + 420,
     "sit_height": DEFAULT_BASE_HEIGHT + 63,
     "height_tolerance": 2.0,
@@ -81,6 +82,8 @@ parser.add_argument('--mac-address', dest='mac_address',
                     type=str, help="Mac address of the Idasen desk")
 parser.add_argument('--base-height', dest='base_height', type=int,
                     help="The height of tabletop above ground at lowest position (mm)")
+parser.add_argument('--movement-range', dest='movement_range', type=int,
+                    help="How far above base-height the desk can extend (mm)")
 parser.add_argument('--stand-height', dest='stand_height', type=int,
                     help="The height the desk should be at when standing (mm)")
 parser.add_argument('--sit-height', dest='sit_height', type=int,
@@ -142,7 +145,7 @@ config.update(args)
 
 # recompute base and max height
 BASE_HEIGHT = config['base_height']
-MAX_HEIGHT = BASE_HEIGHT + MOVEMENT_RANGE
+MAX_HEIGHT = BASE_HEIGHT + config['movement_range']
 
 if not config['mac_address']:
     parser.error("Mac address must be provided")
@@ -157,13 +160,13 @@ if config['stand_height'] > MAX_HEIGHT:
     parser.error("Stand height must be less than {}".format(MAX_HEIGHT))
 
 if 'sit_height_offset' in config:
-    if not (0 <= config['sit_height_offset'] <= MOVEMENT_RANGE):
-        parser.error("Sit height offset must be within [0, {}]".format(MOVEMENT_RANGE))
+    if not (0 <= config['sit_height_offset'] <= config['movement_range']):
+        parser.error("Sit height offset must be within [0, {}]".format(config['movement_range']))
     config['sit_height'] = BASE_HEIGHT + config['sit_height_offset']
 
 if 'stand_height_offset' in config:
-    if not (0 <= config['stand_height_offset'] <= MOVEMENT_RANGE):
-        parser.error("Stand height offset must be within [0, {}]".format(MOVEMENT_RANGE))
+    if not (0 <= config['stand_height_offset'] <= config['movement_range']):
+        parser.error("Stand height offset must be within [0, {}]".format(config['movement_range']))
     config['stand_height'] = BASE_HEIGHT + config['stand_height_offset']
 
 config['mac_address'] = config['mac_address'].upper()


### PR DESCRIPTION
Fix #34 

This may also be useful for compatibility with other Linak offerings. Many of them have a shorter range than the one used in the Idasen.