### PR TITLE
Enable forwarded commands with minimal values

### DIFF
--- a/idasen_controller/main.py
+++ b/idasen_controller/main.py
@@ -327,6 +327,10 @@ async def run_command(client, config):
         await move_to(client, target)
     elif config['move_to']:
         # Move to custom height
+        target = mmToRaw(config['move_to'])
+        await move_to(client, target)
+    elif config['move_to_raw']:
+        # Move to custom raw height
         target = config['move_to_raw']
         await move_to(client, target)
     if target:


### PR DESCRIPTION
When processing a forwarded command in run_command() the "move_to" option assumes "move_to_raw" is also populated, and has the correct value.

This is true when using a copy of this software to forward commands to itself, however it isn't necessarily true for when a user is connecting to the server over the network from their own software sending JSON over TCP.

Example commands:
`# echo '{"sit": "True"}' | nc -w 1 192.168.11.184 9123`
`# echo '{"stand": "True"}' | nc -w 1 192.168.11.184 9123`
`# echo '{"move_to": 640}' | nc -w 1 192.168.11.184 9123`
`# echo '{"move_to_raw": 200}' | nc -w 1 192.168.11.184 9123`