### PR TITLE
Add a default None value for config['move_to_raw']

### DIFF
--- a/idasen_controller/main.py
+++ b/idasen_controller/main.py
@@ -71,6 +71,7 @@ config = {
     "stand": False,
     "monitor": False,
     "move_to": None,
+    "move_to_raw": None,
     "server_address": "127.0.0.1",
     "server_port": 9123
 }


### PR DESCRIPTION
Resolving issue from my previous PR where software crashes when a user does not pass any param https://github.com/rhyst/idasen-controller/pull/37

Needed to add a default value of None to move_to_raw in the config array so when processing which command to run in run_command() the if statement does not throw trying to process the line "elif config['move_to_raw']" as the value doesn't exist.

![image](https://user-images.githubusercontent.com/12680312/153318717-b36abadf-79d4-49b9-ac8c-3d7daa46b768.png)
