### PR TITLE
Misc improvement

### DIFF
--- a/idasen_controller/main.py
+++ b/idasen_controller/main.py
@@ -364,7 +364,7 @@ async def run_command(client, config, log=print):
         favouriteValue = config.get("favourites", {}).get(config["move_to"])
         if favouriteValue:
             target = mmToRaw(favouriteValue)
-            log(f'Moving to favourite height: {config["move_to"]}')
+            log(f'Moving to favourite height: {config["move_to"]} ({favouriteValue} mm)')
         else:
             try:
                 target = mmToRaw(int(config["move_to"]))

--- a/idasen_controller/main.py
+++ b/idasen_controller/main.py
@@ -333,6 +333,9 @@ async def connect(client=None, attempt=0):
     except asyncio.exceptions.TimeoutError as e:
         print("Connecting failed - timed out")
         os._exit(1)
+    except OSError as e:
+        print(e)
+        os._exit(1)
 
 async def disconnect(client):
     """Attempt to disconnect cleanly"""

--- a/idasen_controller/main.py
+++ b/idasen_controller/main.py
@@ -293,13 +293,13 @@ async def move_to(client, target, log=print):
         await move_to_target(client, target)
         await asyncio.sleep(0.5)
         height, speed = await get_height_speed(client)
+        if speed == 0:
+            break
         log(
             "Height: {:4.0f}mm Speed: {:2.0f}mm/s".format(
                 rawToMM(height), rawToSpeed(speed)
             )
         )
-        if speed == 0:
-            break
 
 
 async def scan():

--- a/idasen_controller/main.py
+++ b/idasen_controller/main.py
@@ -373,7 +373,7 @@ async def run_command(client, config, log=print):
                 log(f'Not a valid height or favourite position: {config["move_to"]}')
                 return
         if target == initial_height:
-            log(f'Nothing need to do')
+            log(f'Nothing to do - already at specified height')
             return
         await move_to(client, target, log=log)
     if target:

--- a/idasen_controller/main.py
+++ b/idasen_controller/main.py
@@ -372,6 +372,9 @@ async def run_command(client, config, log=print):
             except ValueError:
                 log(f'Not a valid height or favourite position: {config["move_to"]}')
                 return
+        if target == initial_height:
+            log(f'Nothing need to do')
+            return
         await move_to(client, target, log=log)
     if target:
         final_height, speed = struct.unpack(


### PR DESCRIPTION
Thanks for writing this handy tools!
Feel free to pick revise if it's help

## Catch OSError exception
While execute idasen-controller on Windows without Bluetooth enable will get error message from OSError

```
(ikeaDesk) C:\>idasen-controller
Connecting
Something unexpected went wrong:
Traceback (most recent call last):
  File "c:\...\ikeadesk\lib\site-packages\idasen_controller\main.py", line 483, in main
    client = await connect()
  File "c:\...\ikeadesk\lib\site-packages\idasen_controller\main.py", line 323, in connect
    await client.connect(timeout=config["connection_timeout"])
  File "c:\...\ikeadesk\lib\site-packages\bleak\__init__.py", line 471, in connect
    return await self._backend.connect(**kwargs)
  File "c:\...\ikeadesk\lib\site-packages\bleak\backends\winrt\client.py", line 239, in connect
    device = await BleakScanner.find_device_by_address(
  File "c:\...\ikeadesk\lib\site-packages\bleak\__init__.py", line 286, in find_device_by_address
    return await cls.find_device_by_filter(
  File "c:\...\ikeadesk\lib\site-packages\bleak\__init__.py", line 323, in find_device_by_filter
    async with cls(detection_callback=apply_filter, **kwargs):
  File "c:\...\ikeadesk\lib\site-packages\bleak\__init__.py", line 126, in __aenter__
    await self._backend.start()
  File "c:\...\ikeadesk\lib\site-packages\bleak\backends\winrt\scanner.py", line 256, in start
    self.watcher.start()
OSError: [WinError -2147020577] The device is not ready for use
```

With this revision will get 
```
(ikeaDesk) C:\>idasen-controller
[WinError -2147020577] The device is not ready for use
```

## Check speed before log in move_to

Which can prevent speed 0 log printed

## Shows favourite target height while prompt

Prompt as `Moving to favourite height: stand (1100 mm)`
but not `Moving to favourite height: stand`

## Early return while nothing to do
Check target height and initial height before call `move_to`