### PR TITLE
Removed user_id from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Config options:
 | Option               | Description                                                                                  | Default                                              |
 | -------------------- | -------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
 | `mac_address`        | The MAC address (or UUID on MacOS) of the desk. This is required.                            |                                                      |
-| `user_id`            | The user ID (in hex) to use when connecting to the desk. This should not need to be changed. | `01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f 10 11` |
 | `base_height`        | The lowest possible height (mm) of the desk top from the floor.                              | `620`.                                               |
 | `movement_range`     | How far above base height the desk can extend (mm).                                          | `650`.                                               |
 | `adapter_name`       | The adapter name for the bluetooth adapter to use for the connection (Linux only).           | `hci0`                                               |

--- a/idasen_controller/config.py
+++ b/idasen_controller/config.py
@@ -28,7 +28,6 @@ class Commands(str, Enum):
 class Config:
     # Config
     mac_address: Optional[str] = None
-    user_id: str = "01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f 10 11"
     base_height: int = DEFAULT_BASE_HEIGHT
     max_height: int = DEFAULT_BASE_HEIGHT + DEFAULT_MOVEMENT_RANGE
     movement_range: int = DEFAULT_MOVEMENT_RANGE
@@ -69,12 +68,6 @@ class Config:
             dest="mac_address",
             type=str,
             help="Mac address of the Linak desk",
-        )
-        parser.add_argument(
-            "--user-id",
-            dest="user_id",
-            type=str,
-            help="User ID to use when connecting to the desk",
         )
         parser.add_argument(
             "--base-height",

--- a/idasen_controller/desk.py
+++ b/idasen_controller/desk.py
@@ -31,7 +31,7 @@ class Desk:
             # Set user_id to more privileged
             user_id[0] = 1
             print("Setting user ID to {}".format(bytes_to_hex(user_id)))
-            #await DPGService.dpg_command(client, DPGService.DPG.CMD_USER_ID, user_id)
+            await DPGService.dpg_command(client, DPGService.DPG.CMD_USER_ID, user_id)
 
         # Check if base height should be taken from controller
         if config.base_height == 0:
@@ -55,8 +55,8 @@ class Desk:
         if initial_height.value == target.value:
             return
 
-        await ControlService.wakeup(client)
-        await ControlService.stop(client)
+        await cls.wakeup(client)
+        await cls.stop(client)
 
         data = ReferenceInputService.encode_height(target.value)
 

--- a/idasen_controller/desk.py
+++ b/idasen_controller/desk.py
@@ -14,23 +14,34 @@ from .gatt import (
 )
 from .config import config
 from .util import bytes_to_hex, Height, Speed
+import struct
 
 
 class Desk:
     @classmethod
     async def initialise(cls, client: BleakClient) -> None:
-        # Read the user id
-
+        # Read capabilities
         capabilities =  cls.decode_capabilities(await DPGService.dpg_command(client, DPGService.DPG.CMD_GET_CAPABILITIES))
         print("Capabilities: {}".format(capabilities))
-        
-        user_id = (await DPGService.dpg_command(client, DPGService.DPG.CMD_USER_ID))[2:]
-        user_id_hex = bytes_to_hex(user_id)
-        print("User ID: {}".format(user_id_hex))
-        if user_id_hex != config.user_id:
-            print("Setting user ID to".format(config.user_id))
-            await DPGService.dpg_command(client, DPGService.DPG.CMD_USER_ID, bytearray.fromhex(config.user_id))
-            
+
+        # Read the user id
+        user_id = (await DPGService.dpg_command(client, DPGService.DPG.CMD_USER_ID))
+        print("User ID: {}".format(bytes_to_hex(user_id)))
+        if user_id and user_id[0] != 1:
+            # Set user_id to more privileged
+            user_id[0] = 1
+            print("Setting user ID to {}".format(bytes_to_hex(user_id)))
+            #await DPGService.dpg_command(client, DPGService.DPG.CMD_USER_ID, user_id)
+
+        # Check if base height should be taken from controller
+        if config.base_height == 0:
+            resp = (await DPGService.dpg_command(client, DPGService.DPG.CMD_BASE_OFFSET))
+            if resp:
+                base_height = struct.unpack("<H", resp[1:])[0]
+                print("base_height taken from controller {}".format(base_height))
+                config.base_height = base_height/10
+                config.max_height = config.base_height + config.movement_range
+
 
 
     @classmethod
@@ -86,8 +97,7 @@ class Desk:
             pass
 
     @classmethod
-    def decode_capabilities(cls, data: bytearray) -> dict:
-        caps = data[2:]
+    def decode_capabilities(cls, caps: bytearray) -> dict:
         if len(caps) < 2:
             return {}
         capByte = caps[0]

--- a/idasen_controller/example/config.yaml
+++ b/idasen_controller/example/config.yaml
@@ -1,5 +1,4 @@
 mac_address: AA:AA:AA:AA:AA:AA
-user_id: "01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f 10 11"
 scan_timeout: 5
 connection_timeout: 10
 movement_timeout: 30

--- a/idasen_controller/gatt.py
+++ b/idasen_controller/gatt.py
@@ -159,6 +159,7 @@ class DPGDPGCharacteristic(Characteristic):
     uuid = "99fa0011-338a-1024-8a49-009c0215f78a"
 
     CMD_GET_CAPABILITIES = 128
+    CMD_BASE_OFFSET = 129
     CMD_USER_ID = 134
 
     @classmethod
@@ -202,4 +203,8 @@ class DPGService(Service):
             await cls.DPG.read_command(client, command)
         async for sender, data in iter:
             # Return the first response from the callback
-            return data
+            if data[0] == 1:
+                return data[2:]
+            else:
+                return None
+


### PR DESCRIPTION
There is no need to store user_id in the configuration file because we can read from controller and modify only one byte. Storing in a configuration file may also cause some issues when someone incorrectly set the byte responsible for the ability to move the desk.
I also noticed that BASE_HEIGHT offset is different for my desk so I added a read from the controller to be fully synchronized.