### PR TITLE
Get base_height from the config

### DIFF
--- a/linak_controller/main.py
+++ b/linak_controller/main.py
@@ -88,7 +88,7 @@ async def run_command(desk: Desk, command: Command):
         # Move to custom height
         if command["value"] in desk.config["favourites"]:
             target = Height(
-                desk.config["favourites"].get(command["value"]), desk.base_height, True
+                desk.config["favourites"].get(command["value"]), desk.config["base_height"], True
             )
             logger.log(
                 f"""Moving to favourite height: {command["value"]} ({target.human} mm)"""


### PR DESCRIPTION
Custom heights were crashing with:

```console
Something unexpected went wrong:
Traceback (most recent call last):
  File "/home/mark/Projects/linak-controller/linak_controller/main.py", line 224, in main
    await run_command(desk, command)
  File "/home/mark/Projects/linak-controller/linak_controller/main.py", line 91, in run_command
    desk.config["favourites"].get(command["value"]), desk.base_height, True
                                                     ^^^^^^^^^^^^^^^^
AttributeError: 'Desk' object has no attribute 'base_height'

Disconnected  
```

This fixes grabbing the base height value.