### PR TITLE
Add: link to related GNOME extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ And to publish the project to PyPi run:
 Other useful projects that make use of this one:
 
 - [Home Assistant Integration](https://github.com/j5lien/esphome-idasen-desk-controller) by @j5lien
+- [GNOME Extension](https://extensions.gnome.org/extension/8841/linakidasen-desk-controller) by @p-gentili
 
 ## Attribution
 


### PR DESCRIPTION
I've created a small GNOME extension to set the desk into one of the *favourites* positions, hopefully someone else will find it useful.