### PR TITLE
chore: add PyPI project URLs for repo linkage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,20 @@ version = "1.3.2"
 description = "Command line tool for controlling the Linak standing desks"
 authors = [{ name = "Rhys Tyers" }]
 requires-python = ">=3.9"
-license = "MIT"
+license = {text = "MIT"}
+readme = "README.md"
 dependencies = [
     "aiohttp>=3.8.4,<4",
     "appdirs>=1.4.4,<2",
     "bleak>=1.1.1,<2",
     "PyYAML~=6.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/rhyst/linak-controller"
+Repository = "https://github.com/rhyst/linak-controller"
+Changelog = "https://github.com/rhyst/linak-controller/blob/main/CHANGELOG.md"
+Issues = "https://github.com/rhyst/linak-controller/issues"
 
 [project.scripts]
 linak-controller = "linak_controller.main:init"


### PR DESCRIPTION
Added the usual entrypoints in pyproject.toml for PyPi to pickup and reference the repo
