### PR TITLE
Combine --watch functionality with --server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 reference/com.linak.deskcontrol/
 venv/
 .vscode
+.idea
 desk.pickle
 __pycache__/
 *.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 *.egg-info
 dist/
 build/
+.DS_Store

--- a/linak_controller/config.py
+++ b/linak_controller/config.py
@@ -37,6 +37,7 @@ class Config(TypedDict):
     favourites: dict
     forward: bool
     move_command_period: float
+    watch: bool
 
 default_config = Config(
     {
@@ -50,6 +51,7 @@ default_config = Config(
         "favourites": {},
         "forward": False,
         "move_command_period": 0.4,
+        "watch": False,
     }
 )
 

--- a/linak_controller/desk.py
+++ b/linak_controller/desk.py
@@ -3,9 +3,11 @@ High level helper class to organise methods for performing actions with a Linak 
 """
 
 import asyncio
+import struct
+from typing import Awaitable, Callable, List, Optional, Tuple, Union
 from bleak import BleakClient
 from bleak.exc import BleakDBusError
-from typing import Tuple
+
 from .gatt import (
     DPGService,
     ControlService,
@@ -14,7 +16,9 @@ from .gatt import (
 )
 from .config import Config
 from .util import logger, bytes_to_hex, Height, Speed
-import struct
+
+
+SubscriberCallback = Callable[[Height, Speed], Union[None, Awaitable[None]]]
 
 
 class Desk:
@@ -26,8 +30,13 @@ class Desk:
         self.client = client
         self.config = config
 
+        self._subscribers: List[SubscriberCallback] = []
+        self._watching: bool = False
+        self.latest_height: Optional[Height] = None
+        self.latest_speed: Optional[Speed] = None
+
     @classmethod
-    async def initialise(cls, config: Config, client: BleakClient) -> None:
+    async def initialise(cls, config: Config, client: BleakClient) -> "Desk":
         desk = cls(config, client)
 
         # Read capabilities
@@ -57,6 +66,59 @@ class Desk:
         logger.log("Base height:{:4.0f}mm".format(desk.config["base_height"]))
 
         return desk
+
+    def subscribe(self, callback: SubscriberCallback) -> SubscriberCallback:
+        """Register a listener to receive (height, speed) updates."""
+        if callback not in self._subscribers:
+            self._subscribers.append(callback)
+        return callback
+
+    def unsubscribe(self, callback: SubscriberCallback) -> None:
+        """Remove a previously registered listener."""
+        try:
+            self._subscribers.remove(callback)
+        except ValueError:
+            pass # no-op if not registered
+
+    async def start_watching(self) -> None:
+        """Begin listening for height/speed notifications from the desk."""
+        if self._watching:
+            return
+
+        try:
+            height, speed = await self.get_height_speed()
+            self.latest_height = height
+            self.latest_speed = speed
+        except Exception:
+            logger.log("Initial height/speed read failed; continuing.")
+
+        await ReferenceOutputService.ONE.subscribe(self.client, self._on_notification)
+        self._watching = True
+
+    async def stop_watching(self) -> None:
+        """Stop listening for height/speed notifications."""
+        if not self._watching:
+            return
+        try:
+            await ReferenceOutputService.ONE.unsubscribe(self.client)
+        finally:
+            self._watching = False
+
+    def _on_notification(self, sender, data: bytearray) -> None:
+        """Internal BLE notification handler. Decodes data, updates the cache,
+        and fans out to every registered subscriber."""
+        height, speed = ReferenceOutputService.decode_height_speed(data)
+        height.base_height = self.config["base_height"]
+        self.latest_height = height
+        self.latest_speed = speed
+
+        for cb in list(self._subscribers):
+            try:
+                result = cb(height, speed)
+                if asyncio.iscoroutine(result):
+                    asyncio.create_task(result)
+            except Exception as e:
+                logger.log("Subscriber callback raised: {}".format(e))
 
     async def wakeup(self) -> None:
         await ControlService.COMMAND.write_command(
@@ -91,17 +153,19 @@ class Desk:
         return height, speed
 
     async def watch_height_speed(self) -> None:
-        """Listen for height changes"""
-
-        def callback(sender, data):
-            height, speed = ReferenceOutputService.decode_height_speed(data)
-            height.base_height = self.config["base_height"]
+        """Print height/speed changes until cancelled. Backs the CLI `--watch`."""
+        def print_cb(height: Height, speed: Speed) -> None:
             logger.log(
                 "Height:{:4.0f}mm Speed: {:2.0f}mm/s".format(height.human, speed.human)
             )
 
-        await ReferenceOutputService.ONE.subscribe(self.client, callback)
-        await asyncio.Future()
+        # subscribe a printing callback, start watching, then block
+        self.subscribe(print_cb)
+        try:
+            await self.start_watching()
+            await asyncio.Future()
+        finally:
+            self.unsubscribe(print_cb)
 
     async def stop(self) -> None:
         try:

--- a/linak_controller/desk.py
+++ b/linak_controller/desk.py
@@ -104,6 +104,14 @@ class Desk:
         finally:
             self._watching = False
 
+    def mark_disconnected(self) -> bool:
+        """Handle a dropped BLE link. The active notification subscription dies with
+        the old connection, so clear the flag and report whether watching was active
+        so the caller can re-subscribe on the new client after reconnecting."""
+        was_watching = self._watching
+        self._watching = False
+        return was_watching
+
     def _on_notification(self, sender, data: bytearray) -> None:
         """Internal BLE notification handler. Decodes data, updates the cache,
         and fans out to every registered subscriber."""

--- a/linak_controller/example/config.yaml
+++ b/linak_controller/example/config.yaml
@@ -4,6 +4,7 @@ connection_timeout: 10
 adapter_name: hci0
 server_address: "127.0.0.1"
 server_port: 9123
+watch: true
 favourites:
   sit: 683
   stand: 1040

--- a/linak_controller/main.py
+++ b/linak_controller/main.py
@@ -31,10 +31,17 @@ def disconnect_callback(client: BleakClient, _=None):
     global desk_for_disconnect
     if not desk_for_disconnect.disconnecting:
         logger.log("Lost connection with {}".format(client.address))
-        asyncio.create_task(connect(desk_for_disconnect.config, desk_for_disconnect))
+        was_watching = desk_for_disconnect.mark_disconnected()
+        asyncio.create_task(
+            connect(
+                desk_for_disconnect.config,
+                desk_for_disconnect,
+                resume_watching=was_watching,
+            )
+        )
 
 
-async def connect(config: Config, desk=None, attempt=0):
+async def connect(config: Config, desk=None, attempt=0, resume_watching=False):
     """Attempt to connect to the desk"""
     try:
         logger.log("Connecting\r", end="")
@@ -52,6 +59,8 @@ async def connect(config: Config, desk=None, attempt=0):
         else:
             await desk.client.connect(timeout=config["connection_timeout"])
             logger.log("Reconnected: {}".format(config["mac_address"]))
+            if resume_watching:
+                await desk.start_watching()
         return desk
     except BleakError as e:
         logger.log("Connecting failed")

--- a/linak_controller/main.py
+++ b/linak_controller/main.py
@@ -8,7 +8,7 @@ from bleak import BleakClient, BleakError, BleakScanner
 import json
 from functools import partial
 from .config import get_config, Config, Command, Commands
-from .util import Height, logger
+from .util import Height, Speed, logger
 from .desk import Desk
 
 
@@ -23,7 +23,9 @@ async def scan(config: Config):
         logger.log(device)
     return devices
 
+
 desk_for_disconnect = None
+
 
 def disconnect_callback(client: BleakClient, _=None):
     global desk_for_disconnect
@@ -152,9 +154,21 @@ async def run_tcp_forwarded_command(desk: Desk, reader, writer):
 
 async def run_http_server(desk: Desk):
     """Start a server to listen for commands via websocket connection"""
+    if desk.config["watch"]:
+        def log_event(height: Height, speed: Speed) -> None:
+            logger.log(
+                "Height:{:4.0f}mm Speed: {:2.0f}mm/s".format(
+                    height.human, speed.human
+                )
+            )
+        desk.subscribe(log_event)
+        await desk.start_watching()
+        logger.log("Watching desk for height/speed events")
+
     app = web.Application()
     app.router.add_post("/", partial(run_forwarded_http_command, desk))
     app.router.add_get("/ws", partial(run_forwarded_ws_command, desk))
+    app.router.add_get("/events", partial(run_event_stream, desk))
     runner = web.AppRunner(app)
     await runner.setup()
     site = web.TCPSite(runner, desk.config["server_address"], desk.config["server_port"])
@@ -205,6 +219,36 @@ async def run_forwarded_ws_command(desk: Desk, request):
         break
     await asyncio.sleep(1)  # Allows final messages to send on web socket
     await ws.close()
+    return ws
+
+
+async def run_event_stream(desk: Desk, request):
+    """Stream desk height/speed events to a connected client over a websocket."""
+    logger.log("Event stream client connected")
+    ws = web.WebSocketResponse()
+    await ws.prepare(request)
+
+    async def send_event(height: Height, speed: Speed):
+        if ws.closed:
+            return
+        try:
+            await ws.send_json({"height": height.human, "speed": speed.human})
+        except Exception:
+            pass # Connection dropped mid-send; cleanup runs in the finally below.
+
+    desk.subscribe(send_event)
+
+    if desk.latest_height is not None and desk.latest_speed is not None:
+        await send_event(desk.latest_height, desk.latest_speed)
+
+    try:
+        # Hold the connection open. The async iterator exits when the client disconnects
+        async for _ in ws:
+            pass
+    finally:
+        desk.unsubscribe(send_event)
+        logger.log("Event stream client disconnected")
+
     return ws
 
 


### PR DESCRIPTION
RESOLVES #94 

Add a persistent BLE notification subscription to the HTTP server, gated
on a new `watch: bool` config option. When enabled, the server mirrors
desk state changes to stdout (matching the CLI `--watch` behaviour) and
exposes a new `/events` websocket endpoint that streams JSON updates of
the form {"height": <mm>, "speed": <mm/s>} to connected clients.

To support multiple consumers of the same notification stream, the Desk
class gains an in-process pub/sub layer (subscribe / unsubscribe ->
start_watching / stop_watching) with a cached latest_height and
latest_speed. The existing `watch_height_speed` CLI entrypoint is
reimplemented on top of this layer with no change in behaviour.

The TCP server is unchanged and remains request/response only.

Adds corresponding new flag (`watch: True / False`) to config.yaml. Defaults to `false`, so existing configs are unaffected until they opt in.






Re-establish watch subscription after reconnect

While working on the server watch changes I found a pre-existing gap in the reconnect handling. disconnect_callback transparently reconnects the BLE client, but the notification subscription dies with the old connection while desk._watching stays True. After a reconnect the subscription is never rebuilt  and the if self._watching: return guard in start_watching would prevent it anyway so the height/speed event stream goes silently dead.

This affects both the new --server --watch path and the existing CLI --watch. It isn't introduced by the server watch changes, but a long-running server will eventually hit it, so it's worth fixing here.

The fix is small: Desk.mark_disconnected() clears the watching flag on disconnect and reports whether watching was active, and connect re-calls start_watching on the new connection when it was. Existing subscribers are preserved, so clients keep receiving events seamlessly across a reconnect.






Functionality (new and existing) is manually tested on my local macOS machine with my Ikea Idasen